### PR TITLE
Add GitHub Actions workflow for .NET tests

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,30 @@
+name: .NET Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    name: Run unit tests (Chirp.Test only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Run Chirp.Test
+        run: dotnet test tests/Chirp.Test/Chirp.Test.csproj \
+              --configuration Release \
+              --no-build \
+              --verbosity normal


### PR DESCRIPTION
The main workflow needs to depend on this. such that when you release it runs the test workflow and it only can run the release if the testing is working 